### PR TITLE
Adds Musicbrainz tags to lastfm plugin, PSA test, and plugin reload command 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@ test.ini
 what.ini
 cookies.jar
 *.json
-!user_*.json
-!track*.json
+!test/fixtures/*.json
 *.bak
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ cookies.jar
 *.json
 *.bak
 
+.DS_Store
+
 *.py[cod]
 
 # C extensions

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ what.ini
 cookies.jar
 *.json
 *.bak
-
 .DS_Store
 
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ test.ini
 what.ini
 cookies.jar
 *.json
+!user_*.json
+!track*.json
 *.bak
 .DS_Store
 

--- a/docs/config.ini
+++ b/docs/config.ini
@@ -2,10 +2,14 @@
 nick=OneBotTest
 username=TwoBot
 host=my.irc.network
+
 port=6697
 ssl=true
+ssl_verify = CERT_NONE
+
 includes=
   irc3.plugins.uptime
+  onebot.plugins.acl
   onebot.plugins.lastfm
   onebot.plugins.trakt
   onebot.plugins.botui
@@ -30,7 +34,7 @@ guard=onebot.plugins.acl.user_based_policy
 identify_by = mask
 
 [onebot.plugins.acl]
-# Pre-seed acl
+# Userhost without nick
 superadmin=me@my.awesome.host
 
 [onebot.plugins.lastfm]

--- a/docs/config.ini
+++ b/docs/config.ini
@@ -5,7 +5,8 @@ host=my.irc.network
 
 port=6697
 ssl=true
-ssl_verify = CERT_NONE
+# uncomment this if you don't want to check the certificate
+# ssl_verify = CERT_NONE
 
 includes=
   irc3.plugins.uptime
@@ -34,7 +35,6 @@ guard=onebot.plugins.acl.user_based_policy
 identify_by = mask
 
 [onebot.plugins.acl]
-# Userhost without nick
 superadmin=me@my.awesome.host
 
 [onebot.plugins.lastfm]

--- a/docs/config.ini
+++ b/docs/config.ini
@@ -35,6 +35,7 @@ guard=onebot.plugins.acl.user_based_policy
 identify_by = mask
 
 [onebot.plugins.acl]
+# Pre-seed acl
 superadmin=me@my.awesome.host
 
 [onebot.plugins.lastfm]

--- a/onebot/plugins/acl.py
+++ b/onebot/plugins/acl.py
@@ -77,7 +77,7 @@ class ACLPlugin(object):
 
     Configuration settings:
         - ``superadmin``: username to store in the database with
-        - ``all_permissions``: username depends on mask chosen
+        `all_permissions`. username depends on mask chosen
     """
 
     requires = [

--- a/onebot/plugins/acl.py
+++ b/onebot/plugins/acl.py
@@ -77,7 +77,7 @@ class ACLPlugin(object):
 
     Configuration settings:
         - ``superadmin``: username to store in the database with
-        -``all_permissions`: username depends on mask chosen
+        - ``all_permissions``: username depends on mask chosen
     """
 
     requires = [

--- a/onebot/plugins/acl.py
+++ b/onebot/plugins/acl.py
@@ -77,7 +77,7 @@ class ACLPlugin(object):
 
     Configuration settings:
         - ``superadmin``: username to store in the database with
-        ``all_permissions`. username depends on mask chosen.
+        -``all_permissions`: username depends on mask chosen
     """
 
     requires = [

--- a/onebot/plugins/botui.py
+++ b/onebot/plugins/botui.py
@@ -143,7 +143,8 @@ class BotUI(object):
             self.bot.reload(args['<plugin>'])
             self.bot.privmsg(target, "{} reloaded".format(args['<plugin>']))
         else:
-            self.bot.privmsg(target, "{} not a valid plugin".format(args['<plugin>']))
+            self.bot.privmsg(target, "{} not a valid plugin".format(
+                args['<plugin>']))
 
     @command(permission='admin', show_in_help_list=False)
     def restart(self, mask, target, args):

--- a/onebot/plugins/botui.py
+++ b/onebot/plugins/botui.py
@@ -131,15 +131,15 @@ class BotUI(object):
         self.bot.privmsg(target, "Sending {}".format(cmd))
         self.bot.send(cmd)
 
-    @command(permission='admin', show_in_help_list=False)
-    def load(self, mask, target, args):
-        """Load - Reloads a plugin and the config file without restarting the IrcBot
+    @command(name='reload', permission='admin', show_in_help_list=False)
+    def reload_cmd(self, mask, target, args):
+        """Reload - Reloads a plugin and the config file without restarting the IrcBot
 
-          %%load <plugin>...
+          %%reload <plugin>
         """
-        loaded_plugins = self.bot.registry.includes
+        self.bot.registry.includes
 
-        if args['<plugin>'] in loaded_plugins:
+        if ''.join(args['<plugin>']) in self.bot.registry.includes:
             self.bot.reload(args['<plugin>'])
             self.bot.privmsg(target, "{} reloaded".format(args['<plugin>']))
         else:

--- a/onebot/plugins/botui.py
+++ b/onebot/plugins/botui.py
@@ -132,6 +132,15 @@ class BotUI(object):
         self.bot.send(cmd)
 
     @command(permission='admin', show_in_help_list=False)
+    def load(self, mask, target, args):
+        """Load - Reloads a plugin and the config file without restarting the IrcBot
+
+          %%load <plugin>
+        """
+        self.bot.reload(args['<plugin>'])
+        self.bot.privmsg(target, "{} reloaded".format(args['<plugin>']))
+
+    @command(permission='admin', show_in_help_list=False)
     def restart(self, mask, target, args):
         """Quit the IRC bot with an error code to signal restart
 

--- a/onebot/plugins/botui.py
+++ b/onebot/plugins/botui.py
@@ -135,7 +135,7 @@ class BotUI(object):
     def load(self, mask, target, args):
         """Load - Reloads a plugin and the config file without restarting the IrcBot
 
-          %%load <plugin>
+          %%load <plugin>...
         """
         self.bot.reload(args['<plugin>'])
         self.bot.privmsg(target, "{} reloaded".format(args['<plugin>']))

--- a/onebot/plugins/botui.py
+++ b/onebot/plugins/botui.py
@@ -137,8 +137,13 @@ class BotUI(object):
 
           %%load <plugin>...
         """
-        self.bot.reload(args['<plugin>'])
-        self.bot.privmsg(target, "{} reloaded".format(args['<plugin>']))
+        loaded_plugins = self.bot.registry.includes
+
+        if args['<plugin>'] in loaded_plugins:
+            self.bot.reload(args['<plugin>'])
+            self.bot.privmsg(target, "{} reloaded".format(args['<plugin>']))
+        else:
+            self.bot.privmsg(target, "{} not a valid plugin".format(args['<plugin>']))
 
     @command(permission='admin', show_in_help_list=False)
     def restart(self, mask, target, args):

--- a/onebot/plugins/lastfm.py
+++ b/onebot/plugins/lastfm.py
@@ -394,6 +394,6 @@ def _parse_trackinfo(track):
         'playtime': playtime
     }
     if 'mbid' in track:
-            result['mbid'] = track['mbid']
+        result['mbid'] = track['mbid']
 
     return result

--- a/onebot/plugins/lastfm.py
+++ b/onebot/plugins/lastfm.py
@@ -23,10 +23,12 @@ Usage::
 
 """
 import asyncio
-import datetime
+from datetime import datetime
 
 import irc3
 import lastfm.exceptions
+import musicbrainzngs
+from operator import itemgetter
 from irc3.plugins.command import command
 from lastfm import lfm
 
@@ -48,6 +50,7 @@ class LastfmPlugin(object):
         self.bot = bot
         self.log = bot.log.getChild(__name__)
         self.config = bot.config.get(__name__, {})
+        musicbrainzngs.set_useragent(__name__, 1.0)
         try:
             self.app = lfm.App(self.config['api_key'],
                                self.config['api_secret'],
@@ -73,6 +76,7 @@ class LastfmPlugin(object):
             self.bot.privmsg(target, response)
         asyncio.async(wrap())
 
+    # XXX Compare is no longer supported by Last.fm API
     @command
     def compare(self, *args):
         """Gets the tasteometer for the user and the target
@@ -229,7 +233,7 @@ class LastfmPlugin(object):
                 info = _parse_trackinfo(track)
 
                 time_ago = datetime.datetime.utcnow() - info['playtime']
-                if time_ago.days > 0 or time_ago.seconds > (20*60):
+                if time_ago.days > 0 or time_ago.seconds > (20 * 60):
                     response.append('is not currently playing anything '
                                     '(last seen {time} ago)'.format(
                                         time=_time_ago(info['playtime'])))
@@ -268,7 +272,7 @@ class LastfmPlugin(object):
 
                     if 'tags' in info and len(info['tags']) > 0:
                         response.append(
-                            '({})'.format(', '.join(info['tags'][:5])))
+                            '({})'.format(', '.join(info['tags'][:4])))
 
             return ' '.join(response) + '.'
 
@@ -284,7 +288,8 @@ class LastfmPlugin(object):
             return nick
 
     def fetch_extra_trackinfo(self, username, info):
-        """Updates info with extra trackinfo from the last.fm API"""
+        """Updates info with extra trackinfo from the last.fm API and
+        MusicBrainz API"""
         try:
             if 'mbid' in info and False:
                 self.log.debug("asking via mbid")
@@ -306,13 +311,24 @@ class LastfmPlugin(object):
         if 'userplaycount' in api_result:
             info['playcount'] = int(api_result['userplaycount'])
 
-        if 'toptags' in api_result and 'tag' in api_result['toptags']:
-            taglist = api_result['toptags']['tag']
-            if not isinstance(api_result['toptags']['tag'],
-                              list):  # pragma: no cover
-                self.log.warning("Tags is not a list: %r", taglist)
-            else:
-                info['tags'] = [tag['name'] for tag in taglist]
+        # if 'toptags' in api_result and 'tag' in api_result['toptags']:
+        #     taglist = api_result['toptags']['tag']
+        #     if not isinstance(api_result['toptags']['tag'],
+        #                       list):  # pragma: no cover
+        #         self.log.warning("Tags is not a list: %r", taglist)
+        #     else:
+        #         info['tags'] = [tag['name'] for tag in taglist]
+
+        # getting tags from musicbrainz(if they have id)
+        if 'mbid' in info:
+            mb = musicbrainzngs.get_artist_by_id(info['mbid'], includes='tags')
+            sorted_tags = sorted(mb['artist']['tag-list'],
+                                 key=itemgetter('count'), reverse=True)
+
+            tags = []
+            for tag in sorted_tags:
+                tags.append(tag['name'])
+            info['tags'] = tags
 
         if 'userloved' in api_result and not info['loved']:
             info['loved'] = bool(int(api_result['userloved']))
@@ -324,7 +340,7 @@ class LastfmPlugin(object):
 
 def _time_ago(time):
     """Represent time past as a friendly string"""
-    time_ago = datetime.datetime.utcnow() - time
+    time_ago = datetime.utcnow() - time
     timestr = []
     if time_ago.days > 1:
         timestr.append("{} days".format(time_ago.days))
@@ -332,14 +348,14 @@ def _time_ago(time):
         timestr.append("1 day")
 
     # hours
-    hours = time_ago.seconds//(60*60)
+    hours = time_ago.seconds // (60 * 60)
     if hours > 1:
         timestr.append("{} hours".format(hours))
     elif hours == 1:
         timestr.append("1 hour")
 
     # minutes
-    minutes = time_ago.seconds % (60*60)//60
+    minutes = time_ago.seconds % (60 * 60) // 60
     if minutes > 1:
         timestr.append("{} minutes".format(minutes))
     elif minutes == 1:
@@ -353,14 +369,13 @@ def _parse_trackinfo(track):
     now_playing = False
     if '@attr' in track and 'nowplaying' in track['@attr']:
         now_playing = bool(track['@attr']['nowplaying'])
-        playtime = datetime.datetime.utcnow()
+        playtime = datetime.utcnow()
     else:
-        playtime = datetime.datetime.utcfromtimestamp(
+        playtime = datetime.utcfromtimestamp(
             int(track['date']['uts']))
 
     loved = False
-    if 'loved' in track:
-        loved = bool(int(track['loved']))
+    loved = bool(int(track['loved'])) if 'loved' in track
 
     result = {
         'title': track['name'],
@@ -368,9 +383,8 @@ def _parse_trackinfo(track):
         'album': track['album']['#text'],
         'now playing': now_playing,
         'loved': loved,
-        'playtime': playtime}
+        'playtime': playtime
+    }
 
-    if 'mbid' in track:
-        result['mbid'] = track['mbid']
-
+    result['mbid'] = track['mbid'] if 'mbid' in track['artist']
     return result

--- a/onebot/plugins/lastfm.py
+++ b/onebot/plugins/lastfm.py
@@ -320,10 +320,12 @@ class LastfmPlugin(object):
         #         info['tags'] = [tag['name'] for tag in taglist]
 
         # getting tags from musicbrainz(if they have id)
-        if 'mbid' in info:
-            mb = musicbrainzngs.get_artist_by_id(info['mbid'], includes='tags')
-            sorted_tags = sorted(mb['artist']['tag-list'],
-                                 key=itemgetter('count'), reverse=True)
+        if 'art_mbid' in info and info['art_mbid'] != '':
+            mb = musicbrainzngs.get_artist_by_id(
+                info['art_mbid'], includes='tags')
+
+            sorted_tags = sorted(
+                mb['artist']['tag-list'], key=itemgetter('count'), reverse=True)
 
             tags = []
             for tag in sorted_tags:
@@ -375,16 +377,19 @@ def _parse_trackinfo(track):
             int(track['date']['uts']))
 
     loved = False
-    loved = bool(int(track['loved'])) if 'loved' in track
+    if 'loved' in track:
+        loved = bool(int(track['loved']))
 
     result = {
         'title': track['name'],
         'artist': track['artist']['name'],
+        'art_mbid': track['artist']['mbid'],
         'album': track['album']['#text'],
         'now playing': now_playing,
         'loved': loved,
         'playtime': playtime
     }
+    if 'mbid' in track:
+            result['mbid'] = track['mbid']
 
-    result['mbid'] = track['mbid'] if 'mbid' in track['artist']
     return result

--- a/onebot/plugins/lastfm.py
+++ b/onebot/plugins/lastfm.py
@@ -314,14 +314,6 @@ class LastfmPlugin(object):
         if 'userplaycount' in api_result:
             info['playcount'] = int(api_result['userplaycount'])
 
-        # if 'toptags' in api_result and 'tag' in api_result['toptags']:
-        #     taglist = api_result['toptags']['tag']
-        #     if not isinstance(api_result['toptags']['tag'],
-        #                       list):  # pragma: no cover
-        #         self.log.warning("Tags is not a list: %r", taglist)
-        #     else:
-        #         info['tags'] = [tag['name'] for tag in taglist]
-
         # getting tags from musicbrainz(if they have id)
         if 'art_mbid' in info and info['art_mbid'] != '':
             mb = musicbrainzngs.get_artist_by_id(

--- a/onebot/plugins/lastfm.py
+++ b/onebot/plugins/lastfm.py
@@ -85,6 +85,7 @@ class LastfmPlugin(object):
         """
         asyncio.async(self.compare_result(*args))
 
+    # XXX Compare is no longer supported by Last.fm API
     @asyncio.coroutine
     def compare_result(self, mask, target, args):
         lastfm_user = yield from self.get_lastfm_nick(mask.nick)
@@ -152,6 +153,7 @@ class LastfmPlugin(object):
             'Ok, so you are https://last.fm/user/{username}'.format(
                 username=args['<lastfmnick>']))
 
+    # XXX Compare is no longer supported by Last.fm API
     @command
     def ignoreme(self, mask, target, args):
         """Sets that the user wants to be excluded from %%compare
@@ -165,6 +167,7 @@ class LastfmPlugin(object):
             ("I will leave out {nick} from compare. Re-enable compare by "
              "using the unignoreme command").format(nick=mask.nick))
 
+    # XXX Compare is no longer supported by Last.fm API
     @command
     def unignoreme(self, mask, target, args):
         """Sets that the user wants to be included again in %%compare
@@ -232,7 +235,7 @@ class LastfmPlugin(object):
                     track = result['track'][0]
                 info = _parse_trackinfo(track)
 
-                time_ago = datetime.datetime.utcnow() - info['playtime']
+                time_ago = datetime.utcnow() - info['playtime']
                 if time_ago.days > 0 or time_ago.seconds > (20 * 60):
                     response.append('is not currently playing anything '
                                     '(last seen {time} ago)'.format(
@@ -324,13 +327,14 @@ class LastfmPlugin(object):
             mb = musicbrainzngs.get_artist_by_id(
                 info['art_mbid'], includes='tags')
 
-            sorted_tags = sorted(
-                mb['artist']['tag-list'], key=itemgetter('count'), reverse=True)
+            if 'tag-list' in mb['artist']:
+                sorted_tags = sorted(
+                    mb['artist']['tag-list'], key=itemgetter('count'), reverse=True)
 
-            tags = []
-            for tag in sorted_tags:
-                tags.append(tag['name'])
-            info['tags'] = tags
+                tags = []
+                for tag in sorted_tags:
+                    tags.append(tag['name'])
+                info['tags'] = tags
 
         if 'userloved' in api_result and not info['loved']:
             info['loved'] = bool(int(api_result['userloved']))

--- a/onebot/plugins/lastfm.py
+++ b/onebot/plugins/lastfm.py
@@ -329,7 +329,8 @@ class LastfmPlugin(object):
 
             if 'tag-list' in mb['artist']:
                 sorted_tags = sorted(
-                    mb['artist']['tag-list'], key=itemgetter('count'), reverse=True)
+                    mb['artist']['tag-list'], key=itemgetter('count'),
+                    reverse=True)
 
                 tags = []
                 for tag in sorted_tags:

--- a/onebot/plugins/psa.py
+++ b/onebot/plugins/psa.py
@@ -29,5 +29,8 @@ class PSAPlugin(object):
 
             %%psa <message>...
         """
+        msg = ' '.join(args['<message>'] or [])
+        # FIXME channels are only listed if activity (i.e. join, part) is
+        # recorded in them first, not a list of channels the bot is in.
         for channel in self.bot.channels:
-            self.bot.privmsg(channel, ' '.join(args['<message>']))
+            self.bot.privmsg(channel, msg)

--- a/onebot/plugins/psa.py
+++ b/onebot/plugins/psa.py
@@ -27,10 +27,13 @@ class PSAPlugin(object):
     def psa(self, mask, target, args):
         """Broadcast a public service announcement to all channels
 
-            %%psa <message>...
+            %%psa [<message>...]
         """
         msg = ' '.join(args['<message>'] or [])
+        if not msg:
+            self.bot.privmsg(mask.nick, "I need a message to announce")
         # FIXME channels are only listed if activity (i.e. join, part) is
         # recorded in them first, not a list of channels the bot is in.
-        for channel in self.bot.channels:
-            self.bot.privmsg(channel, msg)
+        else:
+            for channel in self.bot.channels:
+                self.bot.privmsg(channel, msg)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ install_requires = [
     'irc3>=0.8.2',
     'wheel',
     'lfmh',
+    'musicbrainzngs',
     'beautifulsoup4',
     'html5lib<=0.9999999',
     'requests']

--- a/tests/fixtures/user_get_mbid_tags_M83.json
+++ b/tests/fixtures/user_get_mbid_tags_M83.json
@@ -1,0 +1,57 @@
+{
+    "artist": {
+        "id": "6d7b7cd4-254b-4c25-83f6-dd20f98ceacd",
+        "type": "Group",
+        "name": "M83",
+        "sort-name": "M83",
+        "country": "FR",
+        "area": {
+            "id": "08310658-51eb-3801-80de-5a0739207115",
+            "name": "France",
+            "sort-name": "France",
+            "iso-3166-1-code-list": ["FR"]
+        },
+        "begin-area": {
+            "id": "d8c8f702-8e5f-4744-8b2c-c4e662ec4ec4",
+            "name": "Antibes",
+            "sort-name": "Antibes"
+        },
+        "life-span": {
+            "begin": "2001"
+        },
+        "tag-list": [{
+            "count": "1",
+            "name": "ambient music"
+        }, {
+            "count": "1",
+            "name": "dance and electronica"
+        }, {
+            "count": "2",
+            "name": "dream pop"
+        }, {
+            "count": "1",
+            "name": "electronic"
+        }, {
+            "count": "1",
+            "name": "electronic music"
+        }, {
+            "count": "1",
+            "name": "french"
+        }, {
+            "count": "1",
+            "name": "score"
+        }, {
+            "count": "1",
+            "name": "shoegaze"
+        }, {
+            "count": "1",
+            "name": "soundtrack"
+        }, {
+            "count": "1",
+            "name": "space rock"
+        }, {
+            "count": "1",
+            "name": "synth pop"
+        }]
+    }
+}

--- a/tests/test_onebot.py
+++ b/tests/test_onebot.py
@@ -24,6 +24,7 @@ class TestOnebot(TestCase):
     def tearDown(self):
         pass
 
+
 if __name__ == '__main__':
     import unittest
     unittest.main()

--- a/tests/test_plugin_lastfm.py
+++ b/tests/test_plugin_lastfm.py
@@ -327,8 +327,6 @@ class LastfmPluginTest(BotTestCase):
             assert not mock.called, "Shouldn't call get_info if not recent"
         self.bot.loop.run_until_complete(wrap())
 
-#####
-
     @patch('lastfm.lfm.User.get_recent_tracks',
            return_value=_get_fixture(
                'user_get_recent_tracks_loved_now_playing.json'))

--- a/tests/test_plugin_lastfm.py
+++ b/tests/test_plugin_lastfm.py
@@ -327,6 +327,8 @@ class LastfmPluginTest(BotTestCase):
             assert not mock.called, "Shouldn't call get_info if not recent"
         self.bot.loop.run_until_complete(wrap())
 
+#####
+
     @patch('lastfm.lfm.User.get_recent_tracks',
            return_value=_get_fixture(
                'user_get_recent_tracks_loved_now_playing.json'))
@@ -368,7 +370,10 @@ class LastfmPluginTest(BotTestCase):
     @patch('lastfm.lfm.Track.get_info',
            return_value=_get_fixture(
                'track_get_info_m83_graveyard_girl.json'))
-    def test_lastfm_played_loved_3_minutes_ago(self, mock, mockb):
+    @patch('musicbrainzngs.get_artist_by_id',
+            return_value=_get_fixture(
+                'user_get_mbid_tags_M83.json'))
+    def test_lastfm_played_loved_3_minutes_ago(self, mock, mockb, mockc):
         @asyncio.coroutine
         def wrap():
             response = yield from self.lastfm.now_playing_response(
@@ -376,7 +381,7 @@ class LastfmPluginTest(BotTestCase):
                 {'<user>': None})
             assert response == (
                 'bar was just playing “M83 – Kim & Jessie” (♥) (3m00s ago) '
-                '(shoegaze, electronic, indie, dream pop, pop).')
+                '(dream pop, ambient music, dance and electronica, electronic).')
 
         self.bot.loop.run_until_complete(wrap())
 
@@ -386,7 +391,10 @@ class LastfmPluginTest(BotTestCase):
     @patch('lastfm.lfm.Track.get_info',
            return_value=_get_fixture(
                'track_get_info_m83_midnight_city_not_loved_5_plays.json'))
-    def test_lastfm_played_loved_count(self, mock, mockb):
+    @patch('musicbrainzngs.get_artist_by_id',
+            return_value=_get_fixture(
+                'user_get_mbid_tags_M83.json'))
+    def test_lastfm_played_loved_count(self, mock, mockb, mockc):
         @asyncio.coroutine
         def wrap():
             response = yield from self.lastfm.now_playing_response(
@@ -394,8 +402,7 @@ class LastfmPluginTest(BotTestCase):
                 {'<user>': None})
             assert response == (
                 'bar was just playing “M83 – Kim & Jessie” (♥) (5 plays) '
-                '(3m00s ago) (electronic, indie, electropop, electro, '
-                'catchy).')
+                '(3m00s ago) (dream pop, ambient music, dance and electronica, electronic).')
         self.bot.loop.run_until_complete(wrap())
 
     @patch('lastfm.lfm.User.get_recent_tracks',
@@ -404,8 +411,11 @@ class LastfmPluginTest(BotTestCase):
     @patch('lastfm.lfm.Track.get_info',
            return_value=_get_fixture(
                'track_get_info_etherwood_weightless_no_tags_loved.json'))
+    @patch('musicbrainzngs.get_artist_by_id',
+            return_value=_get_fixture(
+                'user_get_mbid_tags_M83.json'))
     def test_lastfm_played_3_minutes_ago_loved_from_extra_info(
-            self, mock, mockb):
+            self, mock, mockb, mockc):
         @asyncio.coroutine
         def wrap():
             response = yield from self.lastfm.now_playing_response(
@@ -413,7 +423,8 @@ class LastfmPluginTest(BotTestCase):
                 {'<user>': None})
             assert response == ('bar was just playing '
                                 '“M83 – Kim & Jessie” (♥) '
-                                '(9 plays) (3m00s ago).')
+                                '(9 plays) (3m00s ago) '
+                                '(dream pop, ambient music, dance and electronica, electronic).')
 
         self.bot.loop.run_until_complete(wrap())
 

--- a/tests/test_plugin_lastfm.py
+++ b/tests/test_plugin_lastfm.py
@@ -381,7 +381,8 @@ class LastfmPluginTest(BotTestCase):
                 {'<user>': None})
             assert response == (
                 'bar was just playing “M83 – Kim & Jessie” (♥) (3m00s ago) '
-                '(dream pop, ambient music, dance and electronica, electronic).')
+                '(dream pop, ambient music, dance and electronica, '
+                'electronic).')
 
         self.bot.loop.run_until_complete(wrap())
 
@@ -402,7 +403,8 @@ class LastfmPluginTest(BotTestCase):
                 {'<user>': None})
             assert response == (
                 'bar was just playing “M83 – Kim & Jessie” (♥) (5 plays) '
-                '(3m00s ago) (dream pop, ambient music, dance and electronica, electronic).')
+                '(3m00s ago) (dream pop, ambient music, dance and '
+                'electronica, electronic).')
         self.bot.loop.run_until_complete(wrap())
 
     @patch('lastfm.lfm.User.get_recent_tracks',
@@ -424,7 +426,8 @@ class LastfmPluginTest(BotTestCase):
             assert response == ('bar was just playing '
                                 '“M83 – Kim & Jessie” (♥) '
                                 '(9 plays) (3m00s ago) '
-                                '(dream pop, ambient music, dance and electronica, electronic).')
+                                '(dream pop, ambient music, dance and '
+                                'electronica, electronic).')
 
         self.bot.loop.run_until_complete(wrap())
 

--- a/tests/test_plugin_lastfm.py
+++ b/tests/test_plugin_lastfm.py
@@ -371,8 +371,8 @@ class LastfmPluginTest(BotTestCase):
            return_value=_get_fixture(
                'track_get_info_m83_graveyard_girl.json'))
     @patch('musicbrainzngs.get_artist_by_id',
-            return_value=_get_fixture(
-                'user_get_mbid_tags_M83.json'))
+           return_value=_get_fixture(
+               'user_get_mbid_tags_M83.json'))
     def test_lastfm_played_loved_3_minutes_ago(self, mock, mockb, mockc):
         @asyncio.coroutine
         def wrap():
@@ -392,8 +392,8 @@ class LastfmPluginTest(BotTestCase):
            return_value=_get_fixture(
                'track_get_info_m83_midnight_city_not_loved_5_plays.json'))
     @patch('musicbrainzngs.get_artist_by_id',
-            return_value=_get_fixture(
-                'user_get_mbid_tags_M83.json'))
+           return_value=_get_fixture(
+               'user_get_mbid_tags_M83.json'))
     def test_lastfm_played_loved_count(self, mock, mockb, mockc):
         @asyncio.coroutine
         def wrap():
@@ -412,8 +412,8 @@ class LastfmPluginTest(BotTestCase):
            return_value=_get_fixture(
                'track_get_info_etherwood_weightless_no_tags_loved.json'))
     @patch('musicbrainzngs.get_artist_by_id',
-            return_value=_get_fixture(
-                'user_get_mbid_tags_M83.json'))
+           return_value=_get_fixture(
+               'user_get_mbid_tags_M83.json'))
     def test_lastfm_played_3_minutes_ago_loved_from_extra_info(
             self, mock, mockb, mockc):
         @asyncio.coroutine

--- a/tests/test_plugin_psa.py
+++ b/tests/test_plugin_psa.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+test_plugin_psa
+----------------------------------
+
+Tests for PSA module
+"""
+
+from irc3.testing import BotTestCase, patch
+
+from .test_plugin_users import MockDb
+
+
+class PSATestCase(BotTestCase):
+
+    config = {
+        'includes': [
+            'onebot.plugins.psa',
+            'irc3.plugins.command'
+        ],
+        'cmd': '!'
+    }
+
+    @patch('irc3.plugins.storage.Storage')
+    def setUp(self, mock):
+        super(PSATestCase, self).setUp()
+        self.callFTU()
+        self.bot.db = MockDb({
+            'the@boss': {'permissions': {'all_permissions'}}
+        })
+
+    def test_psa(self):
+        self.bot.dispatch(':rando!user@host JOIN #chan')
+        self.bot.dispatch(':im!the@boss PRIVMSG #chan :!psa best bot')
+        self.assertSent(['PRIVMSG #chan :best bot'])

--- a/tests/test_plugin_psa.py
+++ b/tests/test_plugin_psa.py
@@ -35,3 +35,6 @@ class PSATestCase(BotTestCase):
         self.bot.dispatch(':rando!user@host JOIN #chan')
         self.bot.dispatch(':im!the@boss PRIVMSG #chan :!psa best bot')
         self.assertSent(['PRIVMSG #chan :best bot'])
+
+        self.bot.dispatch(':im!the@boss PRIVMSG #chan :!psa')
+        self.assertSent(['PRIVMSG im :I need a message to announce'])


### PR DESCRIPTION
- Added code to use artist genre tags from Musicbrainz instead of the ones that Last.fm gives for response to the now playing command.
- Test file for PSA plugin
- Added `load` command to the botui module to reload plugins without restarting the bot
- Some minor code cleanup, formatting, and commenting