### PR TITLE
refactor: replace docopt with argparse

### DIFF
--- a/onebot/__init__.py
+++ b/onebot/__init__.py
@@ -31,30 +31,39 @@ class OneBot(irc3.IrcBot):
 
 
 def run(argv=None):  # pragma: no cover
-    """Run OneBot from a config file
-
-    Usage: onebot [options] <config>...
-
-    Options::
-
-        --logdir DIRECTORY  Log directory to use instead of stderr
-        --logdate           Show datetimes in console output
-        -r,--raw            Show raw IRC log on the console
-        -v,--verbose        Increase verbosity
-        -d,--debug          Add debug commands/utils
-    """
+    """Run OneBot from a config file"""
     import sys
-    import docopt
-    import textwrap
+    import argparse
     import os
     from irc3 import utils, config
 
-    args = argv or sys.argv[1:]
-    args = docopt.docopt(textwrap.dedent(run.__doc__), args)  # type: ignore
-    cfg = utils.parse_config("bot", *args["<config>"])
-    cfg.update(verbose=args["--verbose"], debug=args["--debug"])
+    parser = argparse.ArgumentParser(
+        prog="onebot",
+        description="Run OneBot from a config file",
+    )
+    parser.add_argument(
+        "--logdir", metavar="DIRECTORY", help="Log directory to use instead of stderr"
+    )
+    parser.add_argument(
+        "--logdate", action="store_true", help="Show datetimes in console output"
+    )
+    parser.add_argument(
+        "-r", "--raw", action="store_true", help="Show raw IRC log on the console"
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Increase verbosity"
+    )
+    parser.add_argument(
+        "-d", "--debug", action="store_true", help="Add debug commands/utils"
+    )
+    parser.add_argument("config", nargs="+", help="Config file(s)")
 
-    if (logdir := (args["--logdir"] or cfg.get("logdir"))) is not None:
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    cfg = utils.parse_config("bot", *args.config)
+    cfg.update(verbose=args.verbose, debug=args.debug)
+
+    if (logdir := (args.logdir or cfg.get("logdir"))) is not None:
         logdir = os.path.expanduser(logdir)
         OneBot.logging_config = config.get_file_config(logdir)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from onebot import run
+
+
+class TestCLI(unittest.TestCase):
+    @patch("irc3.utils.parse_config")
+    @patch("onebot.OneBot.from_config")
+    @patch("onebot.OneBot.run")
+    def test_run_basic(self, mock_run, mock_from_config, mock_parse_config):
+        mock_parse_config.return_value = {}
+        mock_bot = MagicMock()
+        mock_from_config.return_value = mock_bot
+
+        run(["config.ini"])
+
+        mock_parse_config.assert_called_with("bot", "config.ini")
+        mock_from_config.assert_called_with({"verbose": False, "debug": False})
+        mock_bot.run.assert_called_once()
+
+    @patch("irc3.utils.parse_config")
+    @patch("onebot.OneBot.from_config")
+    @patch("onebot.OneBot.run")
+    def test_run_verbose_debug(self, mock_run, mock_from_config, mock_parse_config):
+        mock_parse_config.return_value = {}
+        mock_bot = MagicMock()
+        mock_from_config.return_value = mock_bot
+
+        run(["--verbose", "-d", "config.ini"])
+
+        mock_parse_config.assert_called_with("bot", "config.ini")
+        mock_from_config.assert_called_with({"verbose": True, "debug": True})
+
+    @patch("irc3.utils.parse_config")
+    @patch("onebot.OneBot.from_config")
+    @patch("onebot.OneBot.run")
+    @patch("onebot.OneBot.logging_config")
+    @patch("irc3.config.get_file_config")
+    @patch("os.path.expanduser")
+    def test_run_logdir(
+        self,
+        mock_expanduser,
+        mock_get_file_config,
+        mock_run,
+        mock_logging_config,
+        mock_from_config,
+        mock_parse_config,
+    ):
+        mock_parse_config.return_value = {}
+        mock_bot = MagicMock()
+        mock_from_config.return_value = mock_bot
+        mock_expanduser.side_effect = lambda x: x
+
+        run(["--logdir", "/tmp/logs", "config.ini"])
+
+        mock_get_file_config.assert_called_with("/tmp/logs")
+
+    @patch("irc3.utils.parse_config")
+    @patch("onebot.OneBot.from_config")
+    @patch("onebot.OneBot.run")
+    def test_run_multiple_configs(self, mock_run, mock_from_config, mock_parse_config):
+        mock_parse_config.return_value = {}
+        mock_bot = MagicMock()
+        mock_from_config.return_value = mock_bot
+
+        run(["config1.ini", "config2.ini"])
+
+        mock_parse_config.assert_called_with("bot", "config1.ini", "config2.ini")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Docopt is unmaintained. This PR refactors the CLI to use `argparse` from the Python standard library.

Changes:
- Refactored `onebot/__init__.py` to use `argparse`.
- Added unit tests in `tests/test_cli.py` to ensure the CLI continues to work as expected.
- Verified that all existing tests pass.

Created with Gemini.