### PR TITLE
refactor: use uv for building and publishing packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ onebot = "onebot:run"
 dev = [
     "freezegun>=1.5.5",
     "pytest",
-    "twine",
     "ruff",
     "betamax",
     "coverage",
@@ -75,12 +74,8 @@ commands =
 
 [testenv:package]
 skip_install = True
-deps =
-    twine
-    build
 commands =
-    python -m build
-    twine check dist/*
+    uv build
 """
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This PR replaces the legacy `build` and `twine` tools with `uv build` and `uv publish`.

### Changes:
- **pyproject.toml**:
  - Removed `twine` from `dev` dependency group.
  - Updated `tox`'s `package` environment to use `uv build` instead of `python -m build` and `twine check`.
- **uv.lock**: Updated to reflect the removal of `twine` and its dependencies.

To build the package now:
```bash
uv build
```

To publish:
```bash
uv publish
```