### PR TITLE
feat: redact nicknames in output to prevent highlighting (#43)

### DIFF
--- a/onebot/plugins/lastfm.py
+++ b/onebot/plugins/lastfm.py
@@ -71,7 +71,10 @@ class LastfmPlugin(object):
             target = mask.nick
 
         response = await self.now_playing_response(mask, args)
-        return response
+        if response.startswith(mask.nick):
+            content = response[len(mask.nick) :]
+            return mask.nick + self.bot.redact_nicks(content, target=target)
+        return self.bot.redact_nicks(response, target=target)
 
     @command
     def setuser(self, mask, target, args):

--- a/onebot/plugins/spotify.py
+++ b/onebot/plugins/spotify.py
@@ -95,20 +95,24 @@ class SpotifyPlugin(object):
             track = currently_playing.item
             artists = ", ".join(artist.name for artist in track.artists)
             album = track.album
-            response = f"{mask.nick} is playing {artists} - “{track.name}”"
+            response = f"{mask.nick} is playing "
+            content = f"{artists} - “{track.name}”"
             if album.name != track.name:
-                response += f" (“{album.name}”)"
-            response += f" ({album.release_date[:4]})"
-            response += f" ({track.uri})"
-            return response
+                content += f" (“{album.name}”)"
+            content += f" ({album.release_date[:4]})"
+            content += f" ({track.uri})"
+            return response + self.bot.redact_nicks(content, target=target)
         elif playing_type == tk.model.CurrentlyPlayingType.ad:
             return "You're playing an ad!"
         elif playing_type == tk.model.CurrentlyPlayingType.episode:
             episode = currently_playing.item
-            response = f"{mask.nick} is listening to episode “{episode.name}” from “{episode.show.name}”"
-            return response
+            response = f"{mask.nick} is listening to "
+            content = f"episode “{episode.name}” from “{episode.show.name}”"
+            return response + self.bot.redact_nicks(content, target=target)
         else:
-            return f"{mask.nick} is listening to something, but I don't know what (type: {playing_type})"
+            response = f"{mask.nick} is listening to "
+            content = f"something, but I don't know what (type: {playing_type})"
+            return response + self.bot.redact_nicks(content, target=target)
 
     async def get_spotify_token(self, nick):
         user = self.bot.get_user(nick)

--- a/onebot/plugins/stonks.py
+++ b/onebot/plugins/stonks.py
@@ -91,13 +91,13 @@ class StonksPlugin(object):
         self.config = bot.config.get(__name__, {})
 
     @command
-    def stonk(self, _mask, _target, args):
+    def stonk(self, _mask, target, args):
         """Check the value of your stonks.
 
         %%stonk <symbol>
         """
         symbol = args["<symbol>"]
-        return stonks(symbol)
+        return self.bot.redact_nicks(stonks(symbol), target=target)
 
     @classmethod
     def reload(cls, old: Self) -> Self:  # pragma: no cover

--- a/onebot/plugins/trakt.py
+++ b/onebot/plugins/trakt.py
@@ -60,7 +60,12 @@ class TrakttvPlugin(object):
         async def wrap():
             response = await self.now_watching_response(mask, args)
             self.log.debug(response)
-            self.bot.privmsg(target, response)
+            if response.startswith(mask.nick):
+                content = response[len(mask.nick) :]
+                msg = mask.nick + self.bot.redact_nicks(content, target=target)
+            else:
+                msg = self.bot.redact_nicks(response, target=target)
+            self.bot.privmsg(target, msg)
 
         asyncio.ensure_future(wrap())
 

--- a/onebot/plugins/urlinfo.py
+++ b/onebot/plugins/urlinfo.py
@@ -454,7 +454,8 @@ class UrlInfo(object):
             if message:
                 messages.append(" ".join(message))
         if messages:
-            self.bot.privmsg(target, "{}.".format(" ".join(messages)))
+            response = "{}.".format(" ".join(messages))
+            self.bot.privmsg(target, self.bot.redact_nicks(response, target=target))
 
     @classmethod
     def reload(cls, old: Self) -> Self:  # pragma: no cover

--- a/onebot/plugins/users.py
+++ b/onebot/plugins/users.py
@@ -170,7 +170,10 @@ class UsersPlugin(object):
 
     @irc3.extend
     def redact_nicks(self, message: str, target: Optional[str] = None) -> str:
-        """Redacts all known nicks in the message"""
+        """Redacts all known nicks in the message.
+
+        If target is provided, only redacts nicks that are in that channel.
+        """
         if target:
             nicks = [n for n, u in self.active_users.items() if target in u.channels]
         else:

--- a/onebot/plugins/users.py
+++ b/onebot/plugins/users.py
@@ -123,6 +123,13 @@ class User(object):
         return self.nick == other.nick
 
 
+def redact_nick(nick: str) -> str:
+    """Inserts a middle dot after the first character of a nick"""
+    if len(nick) <= 1:
+        return nick
+    return nick[0] + "·" + nick[1:]
+
+
 @irc3.plugin
 class UsersPlugin(object):
     """User management plugin for OneBot
@@ -160,6 +167,33 @@ class UsersPlugin(object):
         if not user:
             self.log.warning("Couldn't find %s!", nick)
         return user
+
+    @irc3.extend
+    def redact_nicks(self, message: str, target: Optional[str] = None) -> str:
+        """Redacts all known nicks in the message"""
+        if target:
+            nicks = [n for n, u in self.active_users.items() if target in u.channels]
+        else:
+            nicks = list(self.active_users.keys())
+
+        if not nicks:
+            return message
+
+        def replace(match):
+            return redact_nick(match.group(0))
+
+        # Sort by length descending to match longest possible nick first
+        nicks.sort(key=len, reverse=True)
+        escaped_nicks = [re.escape(n) for n in nicks if len(n) > 1]
+        if not escaped_nicks:
+            return message
+
+        nick_chars = r"A-Za-z0-9_\\\[\]\{\}^`|-"
+        pattern = re.compile(
+            rf"(?<![{nick_chars}])({'|'.join(escaped_nicks)})(?![{nick_chars}])",
+            re.IGNORECASE,
+        )
+        return pattern.sub(replace, message)
 
     @irc3.event(irc3.rfc.JOIN_PART_QUIT)
     def on_join_part_quit(self, mask: IrcString, **kwargs):

--- a/onebot/plugins/wolframalpha.py
+++ b/onebot/plugins/wolframalpha.py
@@ -64,7 +64,7 @@ class WolframAlphaPlugin(object):
                 },
             )
             response.raise_for_status()
-            return f"{mask.nick}: {response.text}"
+            return f"{mask.nick}: {self.bot.redact_nicks(response.text, target=target)}"
         except requests.exceptions.HTTPError as e:
             assert e.response is not None
             if e.response.status_code == 501:

--- a/tests/test_plugin_users.py
+++ b/tests/test_plugin_users.py
@@ -244,7 +244,6 @@ class UsersPluginTest(BotTestCase):
         assert redacted == "Hello [·baz]"
 
         # Method itself DOES redact if it's at the start
-        # The plugins now handle the split.
         msg = "baz: hello"
         redacted = self.bot.redact_nicks(msg, target="#chan")
         assert redacted == "b·az: hello"

--- a/tests/test_plugin_users.py
+++ b/tests/test_plugin_users.py
@@ -221,33 +221,33 @@ class UsersPluginTest(BotTestCase):
 
     def test_redact_nicks(self):
         self.bot.dispatch(":bar!foo@host JOIN #chan")
-        self.bot.dispatch(":Daan!foo@host JOIN #chan")
+        self.bot.dispatch(":baz!foo@host JOIN #chan")
 
         # redact all
-        msg = "Hello bar and Daan"
+        msg = "Hello bar and baz"
         redacted = self.bot.redact_nicks(msg)
-        assert redacted == "Hello b·ar and D·aan"
+        assert redacted == "Hello b·ar and b·az"
 
         # redact for specific channel
-        msg = "Hello bar and Daan"
+        msg = "Hello bar and baz"
         redacted = self.bot.redact_nicks(msg, target="#chan")
-        assert redacted == "Hello b·ar and D·aan"
+        assert redacted == "Hello b·ar and b·az"
 
         # redact for other channel (should be no-op for these nicks)
         redacted = self.bot.redact_nicks(msg, target="#other")
         assert redacted == msg
 
         # test nick with special chars
-        self.bot.dispatch(":[Daan]!foo@host JOIN #chan")
-        msg = "Hello [Daan]"
+        self.bot.dispatch(":[baz]!foo@host JOIN #chan")
+        msg = "Hello [baz]"
         redacted = self.bot.redact_nicks(msg, target="#chan")
-        assert redacted == "Hello [·Daan]"
+        assert redacted == "Hello [·baz]"
 
         # Method itself DOES redact if it's at the start
         # The plugins now handle the split.
-        msg = "Daan: hello"
+        msg = "baz: hello"
         redacted = self.bot.redact_nicks(msg, target="#chan")
-        assert redacted == "D·aan: hello"
+        assert redacted == "b·az: hello"
 
 
 class UserObjectTest(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_plugin_users.py
+++ b/tests/test_plugin_users.py
@@ -172,6 +172,13 @@ class UsersPluginTest(BotTestCase):
         assert self.bot.get_user("bar") is None
         assert self.users.channels == set()
 
+    def test_names(self):
+        self.users.channels.add("#chan")
+        self.bot.dispatch(":server 353 me = #chan :bar bar2 bar3")
+        self.bot.dispatch(":server 366 me #chan :End")
+        # we only add users we know masks for
+        assert len(self.users.active_users) == 0
+
     def test_who(self):
         # Only accept these if we're in that channel
         self.bot.dispatch(":server 352 irc3 #chan ~user host serv bar H@ :hoi")
@@ -211,6 +218,36 @@ class UsersPluginTest(BotTestCase):
     def test_who_on_join(self):
         self.bot.dispatch(":{}!bar@baz JOIN #chan2".format(self.bot.nick))
         self.assertSent(["WHO #chan2"])
+
+    def test_redact_nicks(self):
+        self.bot.dispatch(":bar!foo@host JOIN #chan")
+        self.bot.dispatch(":Daan!foo@host JOIN #chan")
+
+        # redact all
+        msg = "Hello bar and Daan"
+        redacted = self.bot.redact_nicks(msg)
+        assert redacted == "Hello b·ar and D·aan"
+
+        # redact for specific channel
+        msg = "Hello bar and Daan"
+        redacted = self.bot.redact_nicks(msg, target="#chan")
+        assert redacted == "Hello b·ar and D·aan"
+
+        # redact for other channel (should be no-op for these nicks)
+        redacted = self.bot.redact_nicks(msg, target="#other")
+        assert redacted == msg
+
+        # test nick with special chars
+        self.bot.dispatch(":[Daan]!foo@host JOIN #chan")
+        msg = "Hello [Daan]"
+        redacted = self.bot.redact_nicks(msg, target="#chan")
+        assert redacted == "Hello [·Daan]"
+
+        # Method itself DOES redact if it's at the start
+        # The plugins now handle the split.
+        msg = "Daan: hello"
+        redacted = self.bot.redact_nicks(msg, target="#chan")
+        assert redacted == "D·aan: hello"
 
 
 class UserObjectTest(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
This PR implements nickname redaction in the bot's output to prevent highlighting users, addressing issue #43.

### Changes:
- Added a `redact_nicks` method to `UsersPlugin` that inserts a middle dot (`·`) into known nicknames found in a message.
- Updated various plugins to utilize this method:
    - **lastfm, spotify, trakt, wolframalpha**: Now redact only the content of the message, preserving the initial user addressing (e.g., `Nick: ...` or `Nick is ...`).
    - **urlinfo, stonks**: Now redact their entire output.
- Added unit tests in `tests/test_plugin_users.py` to verify the redaction logic and its behavior with user prefixes.

Closes #43