### PR TITLE
ci: refactor python-sandbox to server and add CI/hardening

### DIFF
--- a/.github/workflows/python-sandbox-publish.yml
+++ b/.github/workflows/python-sandbox-publish.yml
@@ -1,0 +1,57 @@
+name: Publish Python Sandbox
+
+on:
+  push:
+    branches: [ "develop", "master" ]
+    tags: [ 'v*.*.*' ]
+    paths:
+      - 'python-sandbox/**'
+      - '.github/workflows/python-sandbox-publish.yml'
+  pull_request:
+    branches: [ "develop", "master" ]
+    paths:
+      - 'python-sandbox/**'
+      - '.github/workflows/python-sandbox-publish.yml'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-python-sandbox
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: python-sandbox
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/python-sandbox-publish.yml
+++ b/.github/workflows/python-sandbox-publish.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}-python-sandbox
+  IMAGE_NAME: ${{ github.repository }}/python-sandbox
 
 jobs:
   build:

--- a/onebot/plugins/python.py
+++ b/onebot/plugins/python.py
@@ -51,7 +51,9 @@ class PythonPlugin:
                 "--memory=50M",
                 "--cpus=0.5",  # CPU shares
                 "--ipc=none",  # inter-process communication (none < priv)
-                "twiggers/python-sandbox",
+                "--tmpfs",
+                "/tmp:rw,noexec,nosuid,size=64k",
+                "ghcr.io/thomwiggers/onebot/python-sandbox",
                 cmd,
             ],
             capture_output=True,

--- a/python-sandbox/Dockerfile
+++ b/python-sandbox/Dockerfile
@@ -1,7 +1,17 @@
-FROM python:slim
-USER nobody:nogroup
+FROM python:3.14-slim
 
+# Create a non-privileged user
+RUN useradd -u 10001 -m sandboxuser
+
+# Remove dangerous/unnecessary binaries and files to reduce attack surface
+RUN rm -rf /usr/local/bin/pip* /usr/local/bin/easy_install* /usr/bin/apt* /usr/bin/dpkg*
+
+WORKDIR /src
 ADD entrypoint.py /src/entrypoint.py
+RUN chmod 555 /src/entrypoint.py
+
+# Switch to non-root user
+USER sandboxuser
 
 ENTRYPOINT ["/usr/local/bin/python3", "/src/entrypoint.py"]
 CMD []

--- a/python-sandbox/Dockerfile
+++ b/python-sandbox/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.14-slim
 
-# Create a non-privileged user
-RUN useradd -u 10001 -m sandboxuser
-
 # Remove dangerous/unnecessary binaries and files to reduce attack surface
 RUN rm -rf /usr/local/bin/pip* /usr/local/bin/easy_install* /usr/bin/apt* /usr/bin/dpkg*
 
@@ -11,7 +8,7 @@ ADD entrypoint.py /src/entrypoint.py
 RUN chmod 555 /src/entrypoint.py
 
 # Switch to non-root user
-USER sandboxuser
+USER nobody:nogroup
 
 ENTRYPOINT ["/usr/local/bin/python3", "/src/entrypoint.py"]
 CMD []

--- a/python-sandbox/entrypoint.py
+++ b/python-sandbox/entrypoint.py
@@ -2,12 +2,34 @@
 
 import io
 import multiprocessing
+import os
+import resource
 import sys
 
 from contextlib import redirect_stdout, redirect_stderr
 
 
 TIMEOUT = 5
+
+
+def set_resource_limits():
+    """Set resource limits for the user process"""
+    # Limit memory to 100MB
+    mem_limit = 100 * 1024 * 1024
+    resource.setrlimit(resource.RLIMIT_AS, (mem_limit, mem_limit))
+    # Limit CPU time to TIMEOUT + 1 seconds
+    resource.setrlimit(resource.RLIMIT_CPU, (TIMEOUT + 1, TIMEOUT + 1))
+    # Disable core dumps
+    resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+    # Limit number of processes to 0 (can't fork)
+    # Note: This might prevent some imports or complex operations,
+    # but it's great for simple snippets.
+    try:
+        resource.setrlimit(resource.RLIMIT_NPROC, (0, 0))
+    except Exception:
+        pass
+    # Limit file size creation
+    resource.setrlimit(resource.RLIMIT_FSIZE, (0, 0))
 
 
 class UserProcess(multiprocessing.Process):
@@ -19,6 +41,7 @@ class UserProcess(multiprocessing.Process):
 
     def run(self):
         """Compile and capture the output"""
+        set_resource_limits()
         out = io.StringIO()
         err = io.StringIO()
 

--- a/python-sandbox/entrypoint.py
+++ b/python-sandbox/entrypoint.py
@@ -2,7 +2,6 @@
 
 import io
 import multiprocessing
-import os
 import resource
 import sys
 


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to build the `python-sandbox` and also applies some hardening.

### Major Changes:
- **CI/CD**: Added workflow to publish the sandbox image to GHCR.

### Hardening Improvements:
- Image attack surface reduction (removed `pip`, `apt`, `dpkg`).
- Strict resource limits (`RLIMIT_AS`, `RLIMIT_CPU`, `RLIMIT_NPROC`) enforced within the sandbox.
